### PR TITLE
changed order of authentication methodes

### DIFF
--- a/backend/AUTH/auth.php
+++ b/backend/AUTH/auth.php
@@ -57,15 +57,15 @@ if ($affich_method == 'HTML' && isset($protectedPost['Valid_CNX']) && trim($prot
     $protectedMdp = $protectedPost['PASSWD'];
 } elseif ($affich_method == 'CAS') {
     require_once('methode/cas.php');
-} elseif ($affich_method != 'HTML' && isset($_SERVER['PHP_AUTH_USER'])) {
-    $login = $_SERVER['PHP_AUTH_USER'];
-    $mdp = $_SERVER['PHP_AUTH_PW'];
+} elseif ($affich_method == 'SSO' && isset($_SERVER['REMOTE_USER']) && !empty($_SERVER['REMOTE_USER'])) {
+    $login = $_SERVER['REMOTE_USER'];
+    $mdp = 'NO_PASSWD';
 } elseif ($affich_method == 'SSO' && isset($_SERVER['HTTP_AUTH_USER']) && !empty($_SERVER['HTTP_AUTH_USER'])) {
     $login = $_SERVER['HTTP_AUTH_USER'];
     $mdp = 'NO_PASSWD';
-}  elseif ($affich_method == 'SSO' && isset($_SERVER['REMOTE_USER']) && !empty($_SERVER['REMOTE_USER'])) {
-    $login = $_SERVER['REMOTE_USER'];
-    $mdp = 'NO_PASSWD';
+} elseif ($affich_method != 'HTML' && isset($_SERVER['PHP_AUTH_USER'])) {
+    $login = $_SERVER['PHP_AUTH_USER'];
+    $mdp = $_SERVER['PHP_AUTH_PW'];
 } 
 
 if (isset($login) && isset($mdp)) {


### PR DESCRIPTION
changed order of authentication methodes beeing processed

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
READY

## Description
The Authentication using REMOTE_USER was missing. Furthermore there was no check for empty HTTP_AUTH_USER. At least the order of these authentication methodes was changed to not run into the "endless loginpage loop" 

## Related Issues


## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
none

#### General informations
Operating system :

#### Server informations
Php version : 5.6.36
Mysql / Mariadb / Percona version : (Debian) version 5.5.60-0
Apache version : Apache/2.4.10 (Debian)

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, logical changes, etc.

1. none

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Login Form
